### PR TITLE
Add AGENTS.md and documentation and Agent Skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,101 @@
+# AGENTS.md
+
+## What this repo is
+- This repo is a single-script installer/migrator for SkillPointer; `setup.py` is the source of truth for behavior.
+- There is no test/lint/typecheck pipeline in-repo; verify changes by running `python setup.py` against a safe skills sandbox.
+
+## Real entrypoints
+- OpenCode mode (default): `python setup.py`
+- Claude mode: `python setup.py --agent claude`
+- Windows wrappers call compatibility mode: `python setup.py install` (`Install.bat`, `Install.vbs`)
+
+## Safety-critical behavior (easy to miss)
+- `setup.py` is stateful and mutates user directories under `$HOME`; it is not a dry-run tool.
+- If a destination skill folder already exists in the hidden vault, it is deleted via `shutil.rmtree(dest)` before move.
+- Migration skips only:
+  - folders ending with `-category-pointer`
+  - empty folders
+- Script exits early if active skills directory does not exist.
+
+## Paths and mode switching
+- OpenCode paths:
+  - active skills: `~/.config/opencode/skills`
+  - hidden vault: `~/.opencode-skill-libraries`
+- Claude paths:
+  - active skills: `~/.claude/skills`
+  - hidden vault: `~/.skillpointer-vault`
+
+## Categorization and pointer generation
+- Category assignment is heuristic and name-based (`DOMAIN_HEURISTICS` in `setup.py`), with `_uncategorized` fallback.
+- Pointer generation scans the hidden vault recursively for `SKILL.md` and creates one `*-category-pointer/SKILL.md` per non-empty category.
+- Pointer text is generated from the in-script template; keep pointer instructions in sync by editing `pointer_template` in `setup.py`, not by hand-editing generated pointers.
+
+## Editing guidance for future agents
+- Prefer minimal edits in `setup.py`; this script is the product.
+- If changing category logic, update only `DOMAIN_HEURISTICS` and/or `get_category_for_skill`.
+- If changing user-facing pointer instructions, update `pointer_template` and regenerate pointers; do not patch generated output as source of truth.
+
+
+## What Are Skills?
+Source: https://agentskills.io/what-are-skills
+
+> Agent Skills are a lightweight, open format for extending AI agent capabilities with specialized knowledge and workflows.
+
+At its core, a skill is a folder containing a `SKILL.md` file. This file includes metadata (`name` and `description`, at minimum) and instructions that tell an agent how to perform a specific task. Skills can also bundle scripts, templates, and reference materials.
+
+```directory theme={null}
+my-skill/
+├── SKILL.md          # Required: instructions + metadata
+├── scripts/          # Optional: executable code
+├── references/       # Optional: documentation
+└── assets/           # Optional: templates, resources
+```
+
+### How skills work
+
+Skills use **progressive disclosure** to manage context efficiently:
+
+1. **Discovery**: At startup, agents load only the name and description of each available skill, just enough to know when it might be relevant.
+
+2. **Activation**: When a task matches a skill's description, the agent reads the full `SKILL.md` instructions into context.
+
+3. **Execution**: The agent follows the instructions, optionally loading referenced files or executing bundled code as needed.
+
+This approach keeps agents fast while giving them access to more context on demand.
+
+### The SKILL.md file
+
+Every skill starts with a `SKILL.md` file containing YAML frontmatter and Markdown instructions:
+
+```mdx theme={null}
+---
+name: pdf-processing
+description: Extract PDF text, fill forms, merge files. Use when handling PDFs.
+---
+
+# PDF Processing
+
+## When to use this skill
+Use this skill when the user needs to work with PDF files...
+
+## How to extract text
+1. Use pdfplumber for text extraction...
+
+## How to fill forms
+...
+```
+
+The following frontmatter is required at the top of `SKILL.md`:
+
+* `name`: A short identifier
+* `description`: When to use this skill
+
+The Markdown body contains the actual instructions and has no specific restrictions on structure or content.
+
+This simple format has some key advantages:
+
+* **Self-documenting**: A skill author or user can read a `SKILL.md` and understand what it does, making skills easy to audit and improve.
+
+* **Extensible**: Skills can range in complexity from just text instructions to executable code, assets, and templates.
+
+* **Portable**: Skills are just files, so they're easy to edit, version, and share.

--- a/docs/agent-skills/skills-specification.md
+++ b/docs/agent-skills/skills-specification.md
@@ -1,0 +1,272 @@
+> ## Documentation Index
+> Fetch the complete documentation index at: https://agentskills.io/llms.txt
+> Use this file to discover all available pages before exploring further.
+
+# Specification
+
+> The complete format specification for Agent Skills.
+
+## Directory structure
+
+A skill is a directory containing, at minimum, a `SKILL.md` file:
+
+```
+skill-name/
+├── SKILL.md          # Required: metadata + instructions
+├── scripts/          # Optional: executable code
+├── references/       # Optional: documentation
+├── assets/           # Optional: templates, resources
+└── ...               # Any additional files or directories
+```
+
+## `SKILL.md` format
+
+The `SKILL.md` file must contain YAML frontmatter followed by Markdown content.
+
+### Frontmatter
+
+| Field           | Required | Constraints                                                                                                       |
+| --------------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
+| `name`          | Yes      | Max 64 characters. Lowercase letters, numbers, and hyphens only. Must not start or end with a hyphen.             |
+| `description`   | Yes      | Max 1024 characters. Non-empty. Describes what the skill does and when to use it.                                 |
+| `license`       | No       | License name or reference to a bundled license file.                                                              |
+| `compatibility` | No       | Max 500 characters. Indicates environment requirements (intended product, system packages, network access, etc.). |
+| `metadata`      | No       | Arbitrary key-value mapping for additional metadata.                                                              |
+| `allowed-tools` | No       | Space-separated string of pre-approved tools the skill may use. (Experimental)                                    |
+
+<Card>
+  **Minimal example:**
+
+  ```markdown SKILL.md theme={null}
+  ---
+  name: skill-name
+  description: A description of what this skill does and when to use it.
+  ---
+  ```
+
+  **Example with optional fields:**
+
+  ```markdown SKILL.md theme={null}
+  ---
+  name: pdf-processing
+  description: Extract PDF text, fill forms, merge files. Use when handling PDFs.
+  license: Apache-2.0
+  metadata:
+    author: example-org
+    version: "1.0"
+  ---
+  ```
+</Card>
+
+#### `name` field
+
+The required `name` field:
+
+* Must be 1-64 characters
+* May only contain unicode lowercase alphanumeric characters (`a-z`) and hyphens (`-`)
+* Must not start or end with a hyphen (`-`)
+* Must not contain consecutive hyphens (`--`)
+* Must match the parent directory name
+
+<Card>
+  **Valid examples:**
+
+  ```yaml theme={null}
+  name: pdf-processing
+  ```
+
+  ```yaml theme={null}
+  name: data-analysis
+  ```
+
+  ```yaml theme={null}
+  name: code-review
+  ```
+
+  **Invalid examples:**
+
+  ```yaml theme={null}
+  name: PDF-Processing  # uppercase not allowed
+  ```
+
+  ```yaml theme={null}
+  name: -pdf  # cannot start with hyphen
+  ```
+
+  ```yaml theme={null}
+  name: pdf--processing  # consecutive hyphens not allowed
+  ```
+</Card>
+
+#### `description` field
+
+The required `description` field:
+
+* Must be 1-1024 characters
+* Should describe both what the skill does and when to use it
+* Should include specific keywords that help agents identify relevant tasks
+
+<Card>
+  **Good example:**
+
+  ```yaml theme={null}
+  description: Extracts text and tables from PDF files, fills PDF forms, and merges multiple PDFs. Use when working with PDF documents or when the user mentions PDFs, forms, or document extraction.
+  ```
+
+  **Poor example:**
+
+  ```yaml theme={null}
+  description: Helps with PDFs.
+  ```
+</Card>
+
+#### `license` field
+
+The optional `license` field:
+
+* Specifies the license applied to the skill
+* We recommend keeping it short (either the name of a license or the name of a bundled license file)
+
+<Card>
+  **Example:**
+
+  ```yaml theme={null}
+  license: Proprietary. LICENSE.txt has complete terms
+  ```
+</Card>
+
+#### `compatibility` field
+
+The optional `compatibility` field:
+
+* Must be 1-500 characters if provided
+* Should only be included if your skill has specific environment requirements
+* Can indicate intended product, required system packages, network access needs, etc.
+
+<Card>
+  **Examples:**
+
+  ```yaml theme={null}
+  compatibility: Designed for Claude Code (or similar products)
+  ```
+
+  ```yaml theme={null}
+  compatibility: Requires git, docker, jq, and access to the internet
+  ```
+
+  ```yaml theme={null}
+  compatibility: Requires Python 3.14+ and uv
+  ```
+</Card>
+
+<Note>
+  Most skills do not need the `compatibility` field.
+</Note>
+
+#### `metadata` field
+
+The optional `metadata` field:
+
+* A map from string keys to string values
+* Clients can use this to store additional properties not defined by the Agent Skills spec
+* We recommend making your key names reasonably unique to avoid accidental conflicts
+
+<Card>
+  **Example:**
+
+  ```yaml theme={null}
+  metadata:
+    author: example-org
+    version: "1.0"
+  ```
+</Card>
+
+#### `allowed-tools` field
+
+The optional `allowed-tools` field:
+
+* A space-separated string of tools that are pre-approved to run
+* Experimental. Support for this field may vary between agent implementations
+
+<Card>
+  **Example:**
+
+  ```yaml theme={null}
+  allowed-tools: Bash(git:*) Bash(jq:*) Read
+  ```
+</Card>
+
+### Body content
+
+The Markdown body after the frontmatter contains the skill instructions. There are no format restrictions. Write whatever helps agents perform the task effectively.
+
+Recommended sections:
+
+* Step-by-step instructions
+* Examples of inputs and outputs
+* Common edge cases
+
+Note that the agent will load this entire file once it's decided to activate a skill. Consider splitting longer `SKILL.md` content into referenced files.
+
+## Optional directories
+
+### `scripts/`
+
+Contains executable code that agents can run. Scripts should:
+
+* Be self-contained or clearly document dependencies
+* Include helpful error messages
+* Handle edge cases gracefully
+
+Supported languages depend on the agent implementation. Common options include Python, Bash, and JavaScript.
+
+### `references/`
+
+Contains additional documentation that agents can read when needed:
+
+* `REFERENCE.md` - Detailed technical reference
+* `FORMS.md` - Form templates or structured data formats
+* Domain-specific files (`finance.md`, `legal.md`, etc.)
+
+Keep individual [reference files](#file-references) focused. Agents load these on demand, so smaller files mean less use of context.
+
+### `assets/`
+
+Contains static resources:
+
+* Templates (document templates, configuration templates)
+* Images (diagrams, examples)
+* Data files (lookup tables, schemas)
+
+## Progressive disclosure
+
+Skills should be structured for efficient use of context:
+
+1. **Metadata** (\~100 tokens): The `name` and `description` fields are loaded at startup for all skills
+2. **Instructions** (\< 5000 tokens recommended): The full `SKILL.md` body is loaded when the skill is activated
+3. **Resources** (as needed): Files (e.g. those in `scripts/`, `references/`, or `assets/`) are loaded only when required
+
+Keep your main `SKILL.md` under 500 lines. Move detailed reference material to separate files.
+
+## File references
+
+When referencing other files in your skill, use relative paths from the skill root:
+
+```markdown SKILL.md theme={null}
+See [the reference guide](references/REFERENCE.md) for details.
+
+Run the extraction script:
+scripts/extract.py
+```
+
+Keep file references one level deep from `SKILL.md`. Avoid deeply nested reference chains.
+
+## Validation
+
+Use the [skills-ref](https://github.com/agentskills/agentskills/tree/main/skills-ref) reference library to validate your skills:
+
+```bash theme={null}
+skills-ref validate ./my-skill
+```
+
+This checks that your `SKILL.md` frontmatter is valid and follows all naming conventions.

--- a/docs/agent-skills/what-are-skills.md
+++ b/docs/agent-skills/what-are-skills.md
@@ -67,8 +67,8 @@ This simple format has some key advantages:
 
 ## Next steps
 
-* [View the specification](/specification) to understand the full format.
-* [Add skills support to your agent](/client-implementation/adding-skills-support) to build a compatible client.
+* [View the specification](https://agentskills.io/specification) to understand the full format.
+* [Add skills support to your agent](https://agentskills.io/client-implementation/adding-skills-support) to build a compatible client.
 * [See example skills](https://github.com/anthropics/skills) on GitHub.
 * [Read authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) for writing effective skills.
 * [Use the reference library](https://github.com/agentskills/agentskills/tree/main/skills-ref) to validate skills and generate prompt XML.

--- a/docs/agent-skills/what-are-skills.md
+++ b/docs/agent-skills/what-are-skills.md
@@ -1,0 +1,74 @@
+> ## Documentation Index
+> Fetch the complete documentation index at: https://agentskills.io/llms.txt
+> Use this file to discover all available pages before exploring further.
+
+# What are skills?
+
+> Agent Skills are a lightweight, open format for extending AI agent capabilities with specialized knowledge and workflows.
+
+At its core, a skill is a folder containing a `SKILL.md` file. This file includes metadata (`name` and `description`, at minimum) and instructions that tell an agent how to perform a specific task. Skills can also bundle scripts, templates, and reference materials.
+
+```directory theme={null}
+my-skill/
+├── SKILL.md          # Required: instructions + metadata
+├── scripts/          # Optional: executable code
+├── references/       # Optional: documentation
+└── assets/           # Optional: templates, resources
+```
+
+## How skills work
+
+Skills use **progressive disclosure** to manage context efficiently:
+
+1. **Discovery**: At startup, agents load only the name and description of each available skill, just enough to know when it might be relevant.
+
+2. **Activation**: When a task matches a skill's description, the agent reads the full `SKILL.md` instructions into context.
+
+3. **Execution**: The agent follows the instructions, optionally loading referenced files or executing bundled code as needed.
+
+This approach keeps agents fast while giving them access to more context on demand.
+
+## The SKILL.md file
+
+Every skill starts with a `SKILL.md` file containing YAML frontmatter and Markdown instructions:
+
+```mdx theme={null}
+---
+name: pdf-processing
+description: Extract PDF text, fill forms, merge files. Use when handling PDFs.
+---
+
+# PDF Processing
+
+## When to use this skill
+Use this skill when the user needs to work with PDF files...
+
+## How to extract text
+1. Use pdfplumber for text extraction...
+
+## How to fill forms
+...
+```
+
+The following frontmatter is required at the top of `SKILL.md`:
+
+* `name`: A short identifier
+* `description`: When to use this skill
+
+The Markdown body contains the actual instructions and has no specific restrictions on structure or content.
+
+This simple format has some key advantages:
+
+* **Self-documenting**: A skill author or user can read a `SKILL.md` and understand what it does, making skills easy to audit and improve.
+
+* **Extensible**: Skills can range in complexity from just text instructions to executable code, assets, and templates.
+
+* **Portable**: Skills are just files, so they're easy to edit, version, and share.
+
+## Next steps
+
+* [View the specification](/specification) to understand the full format.
+* [Add skills support to your agent](/client-implementation/adding-skills-support) to build a compatible client.
+* [See example skills](https://github.com/anthropics/skills) on GitHub.
+* [Read authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) for writing effective skills.
+* [Use the reference library](https://github.com/agentskills/agentskills/tree/main/skills-ref) to validate skills and generate prompt XML.


### PR DESCRIPTION
This pull request adds documentation for Agent Skills from [agentskills.io](https://agentskills.io) in addition to an AGENTS.md file for contributors' agent harnesses to base their knowledge on.

- Added `AGENTS.md` as a top-level explainer and editing guide, describing the repository's purpose, category logic, and best practices for contributors. It also introduces the concept of "skills" and their structure, since the specifics probably aren't established in LLM training data.
- Added `docs/agent-skills/` to explain what Agent Skills are, their structure, how they work (progressive disclosure), and the advantages of the format.